### PR TITLE
fix(ci): load Docker image into local daemon before Trivy scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: previewd:test
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Fixes the docker-build CI job failure where Trivy couldn't find the `previewd:test` image to scan.

## Problem

The docker-build job was failing with:
```
unable to find the specified image 'previewd:test'
```

This occurred because `docker/build-push-action@v6` with `push: false` using Buildx doesn't automatically load the built image into the local Docker daemon. The image only exists in the BuildKit cache, making it unavailable for the Trivy vulnerability scan.

## Solution

Added `load: true` parameter to the `docker/build-push-action` step. This ensures:
- Docker image is built with Buildx (for performance and caching)
- Image is loaded into local Docker daemon (for Trivy to scan)
- Maintains existing cache behavior (gha cache-from/cache-to)
- No changes to other steps or jobs

## Changes

- Added `load: true` to docker/build-push-action configuration in `.github/workflows/ci.yml`

## Testing

The fix will be validated when this PR's CI runs:
- Docker Build job should complete successfully
- Trivy scan should run against the built image
- No regression in other CI jobs

## Impact

- ✅ Fixes docker-build CI job failure
- ✅ Enables vulnerability scanning of Docker images
- ✅ No breaking changes
- ✅ Maintains existing caching strategy

Closes #40