### PR TITLE
fix(ci): don't fail CI on codecov upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           files: ./coverage.out
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false  # Don't fail CI on transient codecov infrastructure issues
           verbose: true
 
       - name: Check coverage thresholds


### PR DESCRIPTION
## Problem

Codecov occasionally has transient infrastructure issues that cause CI failures:
- GPG signature verification failures
- CDN download errors (HTTP 404s returning 15 bytes instead of the binary)
- Empty or corrupted signature files

These are external service issues, not problems with our code or PRs.

## Evidence

From PR #46 CI logs:
```
 -> Downloading https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig

gpg: no valid OpenPGP data found.
gpg: the signature could not be verified.
==> Could not verify signature. Please contact Codecov if problem continues
```

Also saw HTTP errors with retries:
```
100    15  100    15    0     0    251      0
Warning: Problem : HTTP error. Will retry in 2 seconds. 5 retries left.
```

## Solution

Set `fail_ci_if_error: false` in the codecov upload step. This prevents transient codecov infrastructure issues from blocking legitimate PRs.

**Coverage is still enforced** via the separate "Check coverage thresholds" step (line 214), so we don't lose any quality gates.

## Testing

This change will allow PR #46, #47, and #48 to complete CI even if codecov upload fails.

Closes #50