### PR TITLE
feat(argocd): implement ApplicationSet manager for preview environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.1
 	github.com/onsi/gomega v1.38.2
 	k8s.io/api v0.34.1
+	k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	sigs.k8s.io/controller-runtime v0.22.4
@@ -90,7 +91,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/apiserver v0.34.1 // indirect
 	k8s.io/component-base v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/internal/argocd/doc.go
+++ b/internal/argocd/doc.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Previewd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package argocd provides management of ArgoCD ApplicationSets for preview environments.
+//
+// # Overview
+//
+// The argocd package handles GitOps-based deployment of preview services through ArgoCD
+// ApplicationSets. It generates one Application per service using a list generator, enabling
+// automatic deployment and synchronization of preview environment services.
+//
+// # Key Features
+//
+//   - ApplicationSet generation with list generator
+//   - One Application per service in spec.services
+//   - Go templating for dynamic service configuration
+//   - Automated sync with prune and self-heal
+//   - Kustomize integration for namespace isolation
+//   - Owner reference tracking via annotations (cross-namespace)
+//   - Idempotent operations
+//
+// # Usage
+//
+// Create a manager with your cluster client and configuration:
+//
+//	mgr := argocd.NewManager(
+//	    k8sClient,
+//	    scheme,
+//	    "https://github.com/example/app",
+//	    "argocd",
+//	    "default",
+//	)
+//
+// Build an ApplicationSet for a preview environment:
+//
+//	appSet := mgr.BuildApplicationSet(previewEnv, namespace)
+//
+// Ensure an ApplicationSet exists (create or update):
+//
+//	err := mgr.EnsureApplicationSet(ctx, previewEnv, namespace)
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+// Delete an ApplicationSet:
+//
+//	err := mgr.DeleteApplicationSet(ctx, "preview-123", "argocd")
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+// Get Application status:
+//
+//	status, err := mgr.GetApplicationStatus(ctx, "preview-123-auth", "argocd")
+//	if err != nil {
+//	    // Handle error
+//	}
+//	fmt.Printf("Health: %s, Sync: %s\n", status.Health, status.Sync)
+//
+// # ApplicationSet Structure
+//
+// The generated ApplicationSet uses the following structure:
+//
+//	apiVersion: argoproj.io/v1alpha1
+//	kind: ApplicationSet
+//	metadata:
+//	  name: preview-{prNumber}
+//	  namespace: argocd
+//	spec:
+//	  goTemplate: true
+//	  generators:
+//	  - list:
+//	      elements:
+//	      - service: auth
+//	      - service: api
+//	      - service: frontend
+//	  template:
+//	    metadata:
+//	      name: preview-{prNumber}-{{service}}
+//	    spec:
+//	      project: default
+//	      source:
+//	        repoURL: https://github.com/example/app
+//	        path: services/{{service}}
+//	        targetRevision: {headSHA}
+//	        kustomize:
+//	          namePrefix: pr-{prNumber}-
+//	          namespace: {namespace}
+//	          commonLabels:
+//	            preview.previewd.io/pr: "{prNumber}"
+//	      destination:
+//	        server: https://kubernetes.default.svc
+//	        namespace: {namespace}
+//	      syncPolicy:
+//	        automated:
+//	          prune: true
+//	          selfHeal: true
+//	        syncOptions:
+//	        - CreateNamespace=false
+//
+// # Sync Policy
+//
+// The ApplicationSet configures automated sync with:
+//   - Prune: true - removes resources not in Git
+//   - SelfHeal: true - reverts manual changes in cluster
+//   - CreateNamespace: false - namespace created by previewd, not ArgoCD
+//
+// # Owner Reference Tracking
+//
+// Since ApplicationSets are created in the argocd namespace and PreviewEnvironments
+// are typically in a different namespace, cross-namespace owner references are not
+// allowed in Kubernetes. Instead, ownership is tracked via annotations:
+//
+//   - preview.previewd.io/owner-name: PreviewEnvironment name
+//   - preview.previewd.io/owner-namespace: PreviewEnvironment namespace
+//   - preview.previewd.io/owner-uid: PreviewEnvironment UID
+//
+// The previewd controller uses these annotations to clean up ApplicationSets
+// when their owning PreviewEnvironment is deleted.
+//
+// # Types
+//
+// This package defines minimal ArgoCD types (ApplicationSet, Application) to avoid
+// pulling in the full ArgoCD dependency tree which has complex transitive dependencies.
+// These types are compatible with the ArgoCD CRDs and can be used with the
+// controller-runtime client.
+package argocd

--- a/internal/argocd/manager.go
+++ b/internal/argocd/manager.go
@@ -1,0 +1,269 @@
+// Copyright 2025 The Previewd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package argocd provides functionality for managing ArgoCD ApplicationSets
+// for preview environments, enabling GitOps-based deployment of services.
+package argocd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	previewv1alpha1 "github.com/mikelane/previewd/api/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	managedByLabel = "previewd"
+
+	// InClusterServer is the default in-cluster Kubernetes API server URL
+	InClusterServer = "https://kubernetes.default.svc"
+)
+
+// ApplicationStatusInfo contains the health and sync status of an ArgoCD Application
+type ApplicationStatusInfo struct {
+	// Health is the health status (e.g., "Healthy", "Progressing", "Degraded")
+	Health string
+	// Sync is the sync status (e.g., "Synced", "OutOfSync")
+	Sync string
+	// Message is an optional message with more details
+	Message string
+}
+
+// Manager handles ArgoCD ApplicationSet lifecycle for preview environments
+type Manager struct {
+	client          client.Client
+	scheme          *runtime.Scheme
+	repoURL         string
+	argocdNamespace string
+	project         string
+}
+
+// NewManager creates a new ArgoCD manager
+func NewManager(c client.Client, scheme *runtime.Scheme, repoURL, argocdNamespace, project string) *Manager {
+	return &Manager{
+		client:          c,
+		scheme:          scheme,
+		repoURL:         repoURL,
+		argocdNamespace: argocdNamespace,
+		project:         project,
+	}
+}
+
+// BuildApplicationSet creates an ApplicationSet resource for a preview environment.
+// It generates one Application per service using a list generator.
+func (m *Manager) BuildApplicationSet(preview *previewv1alpha1.PreviewEnvironment, namespace string) *ApplicationSet {
+	prNumber := preview.Spec.PRNumber
+	appSetName := m.GetApplicationSetName(prNumber)
+
+	// Build list generator elements - one per service
+	elements := make([]apiextensionsv1.JSON, len(preview.Spec.Services))
+	for i, service := range preview.Spec.Services {
+		elementData := map[string]string{
+			"service": service,
+		}
+		// json.Marshal on map[string]string never fails
+		raw, _ := json.Marshal(elementData) //nolint:errcheck
+		elements[i] = apiextensionsv1.JSON{Raw: raw}
+	}
+
+	appSet := &ApplicationSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "argoproj.io/v1alpha1",
+			Kind:       "ApplicationSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appSetName,
+			Namespace: m.argocdNamespace,
+			Labels: map[string]string{
+				"preview.previewd.io/pr":         fmt.Sprintf("%d", prNumber),
+				"preview.previewd.io/managed-by": managedByLabel,
+			},
+			Annotations: map[string]string{
+				"preview.previewd.io/owner-name":      preview.Name,
+				"preview.previewd.io/owner-namespace": preview.Namespace,
+				"preview.previewd.io/owner-uid":       string(preview.UID),
+			},
+		},
+		Spec: ApplicationSetSpec{
+			GoTemplate: true,
+			GoTemplateOptions: []string{
+				"missingkey=error",
+			},
+			Generators: []ApplicationSetGenerator{
+				{
+					List: &ListGenerator{
+						Elements: elements,
+					},
+				},
+			},
+			Template: ApplicationSetTemplate{
+				ApplicationSetTemplateMeta: ApplicationSetTemplateMeta{
+					Name: fmt.Sprintf("preview-%d-{{service}}", prNumber),
+					Labels: map[string]string{
+						"preview.previewd.io/pr":         fmt.Sprintf("%d", prNumber),
+						"preview.previewd.io/service":    "{{service}}",
+						"preview.previewd.io/managed-by": managedByLabel,
+					},
+				},
+				Spec: ApplicationSpec{
+					Project: m.project,
+					Source: &ApplicationSource{
+						RepoURL:        m.repoURL,
+						Path:           "services/{{service}}",
+						TargetRevision: preview.Spec.HeadSHA,
+						Kustomize: &ApplicationSourceKustomize{
+							NamePrefix: fmt.Sprintf("pr-%d-", prNumber),
+							Namespace:  namespace,
+							CommonLabels: map[string]string{
+								"preview.previewd.io/pr":         fmt.Sprintf("%d", prNumber),
+								"preview.previewd.io/service":    "{{service}}",
+								"preview.previewd.io/managed-by": managedByLabel,
+							},
+						},
+					},
+					Destination: ApplicationDestination{
+						Server:    InClusterServer,
+						Namespace: namespace,
+					},
+					SyncPolicy: &SyncPolicy{
+						Automated: &SyncPolicyAutomated{
+							Prune:    true,
+							SelfHeal: true,
+						},
+						SyncOptions: []string{
+							"CreateNamespace=false",
+							"PruneLast=true",
+						},
+						Retry: &RetryStrategy{
+							Limit: 5,
+							Backoff: &Backoff{
+								Duration:    "5s",
+								MaxDuration: "3m",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return appSet
+}
+
+// EnsureApplicationSet creates or updates an ApplicationSet for the preview environment.
+func (m *Manager) EnsureApplicationSet(ctx context.Context, preview *previewv1alpha1.PreviewEnvironment, namespace string) error {
+	// Input validation
+	if preview == nil {
+		return fmt.Errorf("preview environment cannot be nil")
+	}
+	if namespace == "" {
+		return fmt.Errorf("namespace cannot be empty")
+	}
+
+	appSetName := m.GetApplicationSetName(preview.Spec.PRNumber)
+
+	appSet := &ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appSetName,
+			Namespace: m.argocdNamespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, m.client, appSet, func() error {
+		// Build the desired state
+		desired := m.BuildApplicationSet(preview, namespace)
+
+		// Copy spec from desired to actual
+		appSet.Spec = desired.Spec
+
+		// Set labels
+		if appSet.Labels == nil {
+			appSet.Labels = make(map[string]string)
+		}
+		for k, v := range desired.Labels {
+			appSet.Labels[k] = v
+		}
+
+		// Set annotations for owner tracking (cross-namespace owner refs not allowed)
+		if appSet.Annotations == nil {
+			appSet.Annotations = make(map[string]string)
+		}
+		for k, v := range desired.Annotations {
+			appSet.Annotations[k] = v
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to ensure ApplicationSet for preview %s/%s (PR #%d): %w",
+			preview.Namespace, preview.Name, preview.Spec.PRNumber, err)
+	}
+
+	return nil
+}
+
+// DeleteApplicationSet removes an ApplicationSet by name.
+// Returns nil if the ApplicationSet doesn't exist (idempotent).
+func (m *Manager) DeleteApplicationSet(ctx context.Context, name, namespace string) error {
+	appSet := &ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	err := m.client.Delete(ctx, appSet)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete ApplicationSet %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// GetApplicationStatus retrieves the health and sync status of an ArgoCD Application.
+func (m *Manager) GetApplicationStatus(ctx context.Context, name, namespace string) (*ApplicationStatusInfo, error) {
+	app := &Application{}
+	err := m.client.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, app)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplicationStatusInfo{
+		Health:  app.Status.Health.Status,
+		Sync:    app.Status.Sync.Status,
+		Message: app.Status.Health.Message,
+	}, nil
+}
+
+// GetApplicationSetName generates the ApplicationSet name for a PR number.
+func (m *Manager) GetApplicationSetName(prNumber int) string {
+	return fmt.Sprintf("preview-%d", prNumber)
+}
+
+// GetArgocdNamespace returns the ArgoCD namespace configured for this manager.
+func (m *Manager) GetArgocdNamespace() string {
+	return m.argocdNamespace
+}

--- a/internal/argocd/manager_test.go
+++ b/internal/argocd/manager_test.go
@@ -1,0 +1,975 @@
+// Copyright 2025 The Previewd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	previewv1alpha1 "github.com/mikelane/previewd/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// setupTestClient creates a fake Kubernetes client with necessary schemes
+func setupTestClient(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := previewv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add preview scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add argocd scheme: %v", err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+}
+
+func TestNewManager(t *testing.T) {
+	c := setupTestClient(t)
+	repoURL := "https://github.com/example/app"
+	argocdNamespace := "argocd"
+	project := "default"
+
+	m := NewManager(c, c.Scheme(), repoURL, argocdNamespace, project)
+
+	if m == nil {
+		t.Fatal("NewManager() returned nil")
+	}
+	if m.client == nil {
+		t.Error("Manager client is nil")
+	}
+	if m.scheme == nil {
+		t.Error("Manager scheme is nil")
+	}
+	if m.repoURL != repoURL {
+		t.Errorf("repoURL = %v, want %v", m.repoURL, repoURL)
+	}
+	if m.argocdNamespace != argocdNamespace {
+		t.Errorf("argocdNamespace = %v, want %v", m.argocdNamespace, argocdNamespace)
+	}
+	if m.project != project {
+		t.Errorf("project = %v, want %v", m.project, project)
+	}
+}
+
+// TestBuildApplicationSet_Name verifies the ApplicationSet name follows the pattern "preview-{prNumber}"
+func TestBuildApplicationSet_Name(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth", "api", "frontend"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	expectedName := "preview-123"
+	if appSet.Name != expectedName {
+		t.Errorf("ApplicationSet name = %v, want %v", appSet.Name, expectedName)
+	}
+}
+
+// TestBuildApplicationSet_Namespace verifies the ApplicationSet is created in the argocd namespace
+func TestBuildApplicationSet_Namespace(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth", "api", "frontend"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if appSet.Namespace != "argocd" {
+		t.Errorf("ApplicationSet namespace = %v, want %v", appSet.Namespace, "argocd")
+	}
+}
+
+// TestBuildApplicationSet_ListGeneratorElements verifies the list generator has elements for each service
+func TestBuildApplicationSet_ListGeneratorElements(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth", "api", "frontend"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if len(appSet.Spec.Generators) == 0 {
+		t.Fatal("ApplicationSet has no generators")
+	}
+
+	listGen := appSet.Spec.Generators[0].List
+	if listGen == nil {
+		t.Fatal("ApplicationSet does not have a list generator")
+	}
+
+	if len(listGen.Elements) != 3 {
+		t.Errorf("List generator elements count = %v, want %v", len(listGen.Elements), 3)
+	}
+
+	// Verify each service is represented in the elements
+	expectedServices := map[string]bool{"auth": false, "api": false, "frontend": false}
+	for _, element := range listGen.Elements {
+		var data map[string]interface{}
+		if err := json.Unmarshal(element.Raw, &data); err != nil {
+			t.Fatalf("failed to unmarshal element: %v", err)
+		}
+		if service, ok := data["service"].(string); ok {
+			expectedServices[service] = true
+		}
+	}
+
+	for service, found := range expectedServices {
+		if !found {
+			t.Errorf("service %q not found in list generator elements", service)
+		}
+	}
+}
+
+// TestBuildApplicationSet_AutomatedSyncPolicy verifies automated sync with prune and selfHeal
+func TestBuildApplicationSet_AutomatedSyncPolicy(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-456",
+			Namespace: "previewd-system",
+			UID:       "def-456",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   456,
+			Repository: "example/app",
+			HeadSHA:    "def456abc789012345678901234567890abcdef",
+			Services:   []string{"api"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-456-def45678")
+
+	syncPolicy := appSet.Spec.Template.Spec.SyncPolicy
+	if syncPolicy == nil {
+		t.Fatal("ApplicationSet template has no sync policy")
+	}
+
+	if syncPolicy.Automated == nil {
+		t.Fatal("Sync policy has no automated configuration")
+	}
+
+	if !syncPolicy.Automated.Prune {
+		t.Error("Automated sync policy prune = false, want true")
+	}
+
+	if !syncPolicy.Automated.SelfHeal {
+		t.Error("Automated sync policy selfHeal = false, want true")
+	}
+}
+
+// TestBuildApplicationSet_SyncOptions verifies CreateNamespace=false is in sync options
+func TestBuildApplicationSet_SyncOptions(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-789",
+			Namespace: "previewd-system",
+			UID:       "ghi-789",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   789,
+			Repository: "example/app",
+			HeadSHA:    "ghi789jkl012345678901234567890abcdefgh",
+			Services:   []string{"frontend"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-789-ghi78901")
+
+	syncPolicy := appSet.Spec.Template.Spec.SyncPolicy
+	if syncPolicy == nil {
+		t.Fatal("ApplicationSet template has no sync policy")
+	}
+
+	found := false
+	for _, opt := range syncPolicy.SyncOptions {
+		if opt == "CreateNamespace=false" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Sync options does not include CreateNamespace=false")
+	}
+}
+
+// TestBuildApplicationSet_OwnerReference verifies owner reference is set correctly via annotations
+func TestBuildApplicationSet_OwnerReference(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123-uid",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	// Note: Cross-namespace owner references are not allowed in Kubernetes,
+	// so we use annotations to track the owner instead
+	if appSet.Annotations == nil {
+		t.Fatal("ApplicationSet has no annotations")
+	}
+
+	if appSet.Annotations["preview.previewd.io/owner-uid"] != string(preview.UID) {
+		t.Errorf("owner UID annotation = %v, want %v",
+			appSet.Annotations["preview.previewd.io/owner-uid"], preview.UID)
+	}
+
+	if appSet.Annotations["preview.previewd.io/owner-name"] != preview.Name {
+		t.Errorf("owner name annotation = %v, want %v",
+			appSet.Annotations["preview.previewd.io/owner-name"], preview.Name)
+	}
+
+	if appSet.Annotations["preview.previewd.io/owner-namespace"] != preview.Namespace {
+		t.Errorf("owner namespace annotation = %v, want %v",
+			appSet.Annotations["preview.previewd.io/owner-namespace"], preview.Namespace)
+	}
+}
+
+// TestBuildApplicationSet_KustomizeNamespace verifies Kustomize namespace settings
+func TestBuildApplicationSet_KustomizeNamespace(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	namespace := "preview-pr-123-abc12345"
+	appSet := m.BuildApplicationSet(preview, namespace)
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	if source.Kustomize == nil {
+		t.Fatal("ApplicationSet template source has no Kustomize config")
+	}
+
+	// Verify namespace is set
+	if source.Kustomize.Namespace != namespace {
+		t.Errorf("Kustomize namespace = %v, want %v", source.Kustomize.Namespace, namespace)
+	}
+}
+
+// TestBuildApplicationSet_KustomizeNamePrefix verifies Kustomize name prefix
+func TestBuildApplicationSet_KustomizeNamePrefix(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	if source.Kustomize == nil {
+		t.Fatal("ApplicationSet template source has no Kustomize config")
+	}
+
+	expectedPrefix := "pr-123-"
+	if source.Kustomize.NamePrefix != expectedPrefix {
+		t.Errorf("Kustomize namePrefix = %v, want %v", source.Kustomize.NamePrefix, expectedPrefix)
+	}
+}
+
+// TestBuildApplicationSet_KustomizeCommonLabels verifies Kustomize common labels
+func TestBuildApplicationSet_KustomizeCommonLabels(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	if source.Kustomize == nil {
+		t.Fatal("ApplicationSet template source has no Kustomize config")
+	}
+
+	if source.Kustomize.CommonLabels == nil {
+		t.Fatal("Kustomize has no common labels")
+	}
+
+	expectedPRLabel := "123"
+	if source.Kustomize.CommonLabels["preview.previewd.io/pr"] != expectedPRLabel {
+		t.Errorf("Kustomize commonLabels[preview.previewd.io/pr] = %v, want %v",
+			source.Kustomize.CommonLabels["preview.previewd.io/pr"], expectedPRLabel)
+	}
+}
+
+// TestBuildApplicationSet_ApplicationNamePattern verifies the generated Application name pattern
+func TestBuildApplicationSet_ApplicationNamePattern(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	// The template metadata name should follow the pattern "preview-{prNumber}-{{service}}"
+	expectedNamePattern := "preview-123-{{service}}"
+	if appSet.Spec.Template.Name != expectedNamePattern {
+		t.Errorf("Template name pattern = %v, want %v", appSet.Spec.Template.Name, expectedNamePattern)
+	}
+}
+
+// TestBuildApplicationSet_DestinationNamespace verifies the destination namespace
+func TestBuildApplicationSet_DestinationNamespace(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	namespace := "preview-pr-123-abc12345"
+	appSet := m.BuildApplicationSet(preview, namespace)
+
+	if appSet.Spec.Template.Spec.Destination.Namespace != namespace {
+		t.Errorf("Destination namespace = %v, want %v",
+			appSet.Spec.Template.Spec.Destination.Namespace, namespace)
+	}
+}
+
+// TestBuildApplicationSet_Labels verifies the ApplicationSet has proper labels
+func TestBuildApplicationSet_Labels(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if appSet.Labels == nil {
+		t.Fatal("ApplicationSet has no labels")
+	}
+
+	if appSet.Labels["preview.previewd.io/pr"] != "123" {
+		t.Errorf("label preview.previewd.io/pr = %v, want %v",
+			appSet.Labels["preview.previewd.io/pr"], "123")
+	}
+
+	if appSet.Labels["preview.previewd.io/managed-by"] != "previewd" {
+		t.Errorf("label preview.previewd.io/managed-by = %v, want %v",
+			appSet.Labels["preview.previewd.io/managed-by"], "previewd")
+	}
+}
+
+// TestBuildApplicationSet_SourcePath verifies the source path includes service templating
+func TestBuildApplicationSet_SourcePath(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	// The path should use Go templating for the service name
+	expectedPath := "services/{{service}}"
+	if source.Path != expectedPath {
+		t.Errorf("Source path = %v, want %v", source.Path, expectedPath)
+	}
+}
+
+// TestBuildApplicationSet_GoTemplate verifies Go templating is enabled
+func TestBuildApplicationSet_GoTemplate(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if !appSet.Spec.GoTemplate {
+		t.Error("GoTemplate = false, want true")
+	}
+}
+
+// TestEnsureApplicationSet_Creates creates the ApplicationSet if it doesn't exist
+func TestEnsureApplicationSet_Creates(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth", "api"},
+		},
+	}
+
+	err := m.EnsureApplicationSet(context.Background(), preview, "preview-pr-123-abc12345")
+	if err != nil {
+		t.Fatalf("EnsureApplicationSet() error = %v", err)
+	}
+
+	// Verify the ApplicationSet was created
+	appSet := &ApplicationSet{}
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name:      "preview-123",
+		Namespace: "argocd",
+	}, appSet)
+	if err != nil {
+		t.Fatalf("failed to get created ApplicationSet: %v", err)
+	}
+
+	if appSet.Name != "preview-123" {
+		t.Errorf("ApplicationSet name = %v, want %v", appSet.Name, "preview-123")
+	}
+}
+
+// TestEnsureApplicationSet_Idempotent verifies calling twice doesn't error
+func TestEnsureApplicationSet_Idempotent(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	// First call
+	err := m.EnsureApplicationSet(context.Background(), preview, "preview-pr-123-abc12345")
+	if err != nil {
+		t.Fatalf("first EnsureApplicationSet() error = %v", err)
+	}
+
+	// Second call should not error
+	err = m.EnsureApplicationSet(context.Background(), preview, "preview-pr-123-abc12345")
+	if err != nil {
+		t.Fatalf("second EnsureApplicationSet() error = %v", err)
+	}
+}
+
+// TestDeleteApplicationSet_Deletes verifies deletion works
+func TestDeleteApplicationSet_Deletes(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	// Create an ApplicationSet first
+	appSet := &ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-123",
+			Namespace: "argocd",
+		},
+	}
+	if err := c.Create(context.Background(), appSet); err != nil {
+		t.Fatalf("failed to create ApplicationSet: %v", err)
+	}
+
+	// Delete it
+	err := m.DeleteApplicationSet(context.Background(), "preview-123", "argocd")
+	if err != nil {
+		t.Fatalf("DeleteApplicationSet() error = %v", err)
+	}
+
+	// Verify it's deleted
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name:      "preview-123",
+		Namespace: "argocd",
+	}, &ApplicationSet{})
+	if !errors.IsNotFound(err) {
+		t.Error("ApplicationSet should be deleted")
+	}
+}
+
+// TestDeleteApplicationSet_NotFoundNoError verifies deleting non-existent ApplicationSet doesn't error
+func TestDeleteApplicationSet_NotFoundNoError(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	err := m.DeleteApplicationSet(context.Background(), "non-existent", "argocd")
+	if err != nil {
+		t.Errorf("DeleteApplicationSet() for non-existent should not error, got %v", err)
+	}
+}
+
+// TestGetApplicationStatus_Healthy verifies getting status for a healthy application
+func TestGetApplicationStatus_Healthy(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	// Create an Application with Healthy status
+	app := &Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-123-auth",
+			Namespace: "argocd",
+		},
+		Status: ApplicationStatus{
+			Health: HealthStatus{
+				Status: "Healthy",
+			},
+			Sync: SyncStatus{
+				Status: "Synced",
+			},
+		},
+	}
+	if err := c.Create(context.Background(), app); err != nil {
+		t.Fatalf("failed to create Application: %v", err)
+	}
+
+	status, err := m.GetApplicationStatus(context.Background(), "preview-123-auth", "argocd")
+	if err != nil {
+		t.Fatalf("GetApplicationStatus() error = %v", err)
+	}
+
+	if status.Health != "Healthy" {
+		t.Errorf("Health = %v, want %v", status.Health, "Healthy")
+	}
+
+	if status.Sync != "Synced" {
+		t.Errorf("Sync = %v, want %v", status.Sync, "Synced")
+	}
+}
+
+// TestGetApplicationStatus_Progressing verifies getting status for a progressing application
+func TestGetApplicationStatus_Progressing(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	// Create an Application with Progressing status
+	app := &Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preview-123-api",
+			Namespace: "argocd",
+		},
+		Status: ApplicationStatus{
+			Health: HealthStatus{
+				Status: "Progressing",
+			},
+			Sync: SyncStatus{
+				Status: "OutOfSync",
+			},
+		},
+	}
+	if err := c.Create(context.Background(), app); err != nil {
+		t.Fatalf("failed to create Application: %v", err)
+	}
+
+	status, err := m.GetApplicationStatus(context.Background(), "preview-123-api", "argocd")
+	if err != nil {
+		t.Fatalf("GetApplicationStatus() error = %v", err)
+	}
+
+	if status.Health != "Progressing" {
+		t.Errorf("Health = %v, want %v", status.Health, "Progressing")
+	}
+}
+
+// TestGetApplicationStatus_NotFound verifies error for non-existent application
+func TestGetApplicationStatus_NotFound(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	_, err := m.GetApplicationStatus(context.Background(), "preview-999-missing", "argocd")
+	if err == nil {
+		t.Error("GetApplicationStatus() should return error for non-existent application")
+	}
+
+	if !errors.IsNotFound(err) {
+		t.Errorf("error should be NotFound, got %v", err)
+	}
+}
+
+// TestBuildApplicationSet_Project verifies the project is set correctly
+func TestBuildApplicationSet_Project(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "preview-project")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if appSet.Spec.Template.Spec.Project != "preview-project" {
+		t.Errorf("Project = %v, want %v", appSet.Spec.Template.Spec.Project, "preview-project")
+	}
+}
+
+// TestBuildApplicationSet_TargetRevision verifies the target revision uses HEAD SHA
+func TestBuildApplicationSet_TargetRevision(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	if source.TargetRevision != preview.Spec.HeadSHA {
+		t.Errorf("TargetRevision = %v, want %v", source.TargetRevision, preview.Spec.HeadSHA)
+	}
+}
+
+// TestBuildApplicationSet_RepoURL verifies the repository URL is set correctly
+func TestBuildApplicationSet_RepoURL(t *testing.T) {
+	c := setupTestClient(t)
+	expectedRepoURL := "https://github.com/example/app"
+	m := NewManager(c, c.Scheme(), expectedRepoURL, "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	source := appSet.Spec.Template.Spec.Source
+	if source == nil {
+		t.Fatal("ApplicationSet template has no source")
+	}
+
+	if source.RepoURL != expectedRepoURL {
+		t.Errorf("RepoURL = %v, want %v", source.RepoURL, expectedRepoURL)
+	}
+}
+
+// TestEnsureApplicationSet_NilPreview tests validation
+func TestEnsureApplicationSet_NilPreview(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	err := m.EnsureApplicationSet(context.Background(), nil, "preview-ns")
+	if err == nil {
+		t.Error("EnsureApplicationSet() should return error for nil preview")
+	}
+}
+
+// TestEnsureApplicationSet_EmptyNamespace tests validation
+func TestEnsureApplicationSet_EmptyNamespace(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	err := m.EnsureApplicationSet(context.Background(), preview, "")
+	if err == nil {
+		t.Error("EnsureApplicationSet() should return error for empty namespace")
+	}
+}
+
+// TestGetApplicationSetName verifies the ApplicationSet name generation
+func TestGetApplicationSetName(t *testing.T) {
+	tests := []struct {
+		prNumber int
+		want     string
+	}{
+		{prNumber: 1, want: "preview-1"},
+		{prNumber: 123, want: "preview-123"},
+		{prNumber: 9999, want: "preview-9999"},
+	}
+
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := m.GetApplicationSetName(tt.prNumber)
+			if got != tt.want {
+				t.Errorf("GetApplicationSetName(%d) = %v, want %v", tt.prNumber, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildApplicationSet_DestinationServer verifies the destination server is set
+func TestBuildApplicationSet_DestinationServer(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	// Default to in-cluster
+	expectedServer := "https://kubernetes.default.svc"
+	if appSet.Spec.Template.Spec.Destination.Server != expectedServer {
+		t.Errorf("Destination server = %v, want %v",
+			appSet.Spec.Template.Spec.Destination.Server, expectedServer)
+	}
+}
+
+// TestBuildApplicationSet_ManagedByLabel verifies the managed-by label
+func TestBuildApplicationSet_ManagedByLabel(t *testing.T) {
+	c := setupTestClient(t)
+	m := NewManager(c, c.Scheme(), "https://github.com/example/app", "argocd", "default")
+
+	preview := &previewv1alpha1.PreviewEnvironment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-123",
+			Namespace: "previewd-system",
+			UID:       "abc-123",
+		},
+		Spec: previewv1alpha1.PreviewEnvironmentSpec{
+			PRNumber:   123,
+			Repository: "example/app",
+			HeadSHA:    "abc123def456789012345678901234567890abcd",
+			Services:   []string{"auth"},
+		},
+	}
+
+	appSet := m.BuildApplicationSet(preview, "preview-pr-123-abc12345")
+
+	if appSet.Labels["preview.previewd.io/managed-by"] != "previewd" {
+		t.Errorf("managed-by label = %v, want previewd",
+			appSet.Labels["preview.previewd.io/managed-by"])
+	}
+}

--- a/internal/argocd/types.go
+++ b/internal/argocd/types.go
@@ -1,0 +1,687 @@
+// Copyright 2025 The Previewd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Struct field order must match ArgoCD API for JSON serialization compatibility.
+//
+//nolint:govet // fieldalignment warnings ignored - field order matches ArgoCD CRD API
+package argocd
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupVersion is group version used to register these objects
+var GroupVersion = schema.GroupVersion{Group: "argoproj.io", Version: "v1alpha1"}
+
+// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+var SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
+// AddToScheme adds the types in this group-version to the given scheme.
+var AddToScheme = SchemeBuilder.AddToScheme
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&ApplicationSet{},
+		&ApplicationSetList{},
+		&Application{},
+		&ApplicationList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
+
+// ApplicationSet is a set of Application resources
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type ApplicationSet struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
+	Spec              ApplicationSetSpec   `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+	Status            ApplicationSetStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// DeepCopyObject returns a deep copy of the ApplicationSet
+func (in *ApplicationSet) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSet)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSet) DeepCopyInto(out *ApplicationSet) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopy returns a deep copy of the ApplicationSet
+func (in *ApplicationSet) DeepCopy() *ApplicationSet {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSet)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetList is a list of ApplicationSet resources
+// +kubebuilder:object:root=true
+type ApplicationSetList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ApplicationSet `json:"items"`
+}
+
+// DeepCopyObject returns a deep copy of the ApplicationSetList
+func (in *ApplicationSetList) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetList) DeepCopyInto(out *ApplicationSetList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ApplicationSet, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetList
+func (in *ApplicationSetList) DeepCopy() *ApplicationSetList {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetSpec represents a class of application set state
+type ApplicationSetSpec struct {
+	// GoTemplate enables Go templating in the ApplicationSet
+	GoTemplate bool `json:"goTemplate,omitempty"`
+	// GoTemplateOptions specifies options for Go templating
+	GoTemplateOptions []string `json:"goTemplateOptions,omitempty"`
+	// Generators is a list of generators to generate Applications
+	Generators []ApplicationSetGenerator `json:"generators"`
+	// Template is the template for generating Applications
+	Template ApplicationSetTemplate `json:"template"`
+	// SyncPolicy controls the sync behavior of the ApplicationSet
+	SyncPolicy *ApplicationSetSyncPolicy `json:"syncPolicy,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetSpec) DeepCopyInto(out *ApplicationSetSpec) {
+	*out = *in
+	if in.GoTemplateOptions != nil {
+		in, out := &in.GoTemplateOptions, &out.GoTemplateOptions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Generators != nil {
+		in, out := &in.Generators, &out.Generators
+		*out = make([]ApplicationSetGenerator, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	in.Template.DeepCopyInto(&out.Template)
+	if in.SyncPolicy != nil {
+		in, out := &in.SyncPolicy, &out.SyncPolicy
+		*out = new(ApplicationSetSyncPolicy)
+		**out = **in
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetSpec
+func (in *ApplicationSetSpec) DeepCopy() *ApplicationSetSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetStatus contains status information for the ApplicationSet
+type ApplicationSetStatus struct {
+	// Conditions contains the conditions of the ApplicationSet
+	Conditions []ApplicationSetCondition `json:"conditions,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetStatus) DeepCopyInto(out *ApplicationSetStatus) {
+	*out = *in
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]ApplicationSetCondition, len(*in))
+		copy(*out, *in)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetStatus
+func (in *ApplicationSetStatus) DeepCopy() *ApplicationSetStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetCondition contains details about an ApplicationSet condition
+type ApplicationSetCondition struct {
+	// Type is the type of the condition
+	Type string `json:"type"`
+	// Status is the status of the condition
+	Status string `json:"status"`
+	// Message contains human-readable message indicating details about the condition
+	Message string `json:"message,omitempty"`
+	// Reason is a brief machine-readable explanation for the condition's state
+	Reason string `json:"reason,omitempty"`
+}
+
+// ApplicationSetGenerator is a generator to generate Applications
+type ApplicationSetGenerator struct {
+	// List generator
+	List *ListGenerator `json:"list,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetGenerator) DeepCopyInto(out *ApplicationSetGenerator) {
+	*out = *in
+	if in.List != nil {
+		in, out := &in.List, &out.List
+		*out = new(ListGenerator)
+		(*in).DeepCopyInto(*out)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetGenerator
+func (in *ApplicationSetGenerator) DeepCopy() *ApplicationSetGenerator {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetGenerator)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ListGenerator generates Applications from a list of elements
+type ListGenerator struct {
+	// Elements is a list of element objects
+	Elements []apiextensionsv1.JSON `json:"elements"`
+	// Template is an optional template to override the default template
+	Template ApplicationSetTemplate `json:"template,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ListGenerator) DeepCopyInto(out *ListGenerator) {
+	*out = *in
+	if in.Elements != nil {
+		in, out := &in.Elements, &out.Elements
+		*out = make([]apiextensionsv1.JSON, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	in.Template.DeepCopyInto(&out.Template)
+}
+
+// DeepCopy returns a deep copy of the ListGenerator
+func (in *ListGenerator) DeepCopy() *ListGenerator {
+	if in == nil {
+		return nil
+	}
+	out := new(ListGenerator)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetTemplate represents the template for generated Applications
+type ApplicationSetTemplate struct {
+	// ApplicationSetTemplateMeta is the metadata for the Application template
+	ApplicationSetTemplateMeta `json:"metadata"`
+	// Spec is the Application spec template
+	Spec ApplicationSpec `json:"spec"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetTemplate) DeepCopyInto(out *ApplicationSetTemplate) {
+	*out = *in
+	in.ApplicationSetTemplateMeta.DeepCopyInto(&out.ApplicationSetTemplateMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetTemplate
+func (in *ApplicationSetTemplate) DeepCopy() *ApplicationSetTemplate {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetTemplate)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetTemplateMeta is the metadata template for Applications
+type ApplicationSetTemplateMeta struct {
+	// Name is the template for the Application name
+	Name string `json:"name,omitempty"`
+	// Namespace is the namespace for the Application
+	Namespace string `json:"namespace,omitempty"`
+	// Labels are the labels for the Application
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations are the annotations for the Application
+	Annotations map[string]string `json:"annotations,omitempty"`
+	// Finalizers are the finalizers for the Application
+	Finalizers []string `json:"finalizers,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSetTemplateMeta) DeepCopyInto(out *ApplicationSetTemplateMeta) {
+	*out = *in
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Finalizers != nil {
+		in, out := &in.Finalizers, &out.Finalizers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSetTemplateMeta
+func (in *ApplicationSetTemplateMeta) DeepCopy() *ApplicationSetTemplateMeta {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSetTemplateMeta)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSetSyncPolicy controls the sync behavior of the ApplicationSet
+type ApplicationSetSyncPolicy struct {
+	// PreserveResourcesOnDeletion preserves the resources when the ApplicationSet is deleted
+	PreserveResourcesOnDeletion bool `json:"preserveResourcesOnDeletion,omitempty"`
+}
+
+// Application is a definition of Application resource
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type Application struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              ApplicationSpec   `json:"spec"`
+	Status            ApplicationStatus `json:"status,omitempty"`
+}
+
+// DeepCopyObject returns a deep copy of the Application
+func (in *Application) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(Application)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *Application) DeepCopyInto(out *Application) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopy returns a deep copy of the Application
+func (in *Application) DeepCopy() *Application {
+	if in == nil {
+		return nil
+	}
+	out := new(Application)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationList is a list of Application resources
+// +kubebuilder:object:root=true
+type ApplicationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Application `json:"items"`
+}
+
+// DeepCopyObject returns a deep copy of the ApplicationList
+func (in *ApplicationList) DeepCopyObject() runtime.Object {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationList) DeepCopyInto(out *ApplicationList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Application, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationList
+func (in *ApplicationList) DeepCopy() *ApplicationList {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSpec represents desired application state
+type ApplicationSpec struct {
+	// Source is a reference to the source of the application manifests
+	Source *ApplicationSource `json:"source,omitempty"`
+	// Destination is a reference to the target cluster and namespace
+	Destination ApplicationDestination `json:"destination"`
+	// Project is a reference to the project this application belongs to
+	Project string `json:"project"`
+	// SyncPolicy controls when and how a sync will be performed
+	SyncPolicy *SyncPolicy `json:"syncPolicy,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSpec) DeepCopyInto(out *ApplicationSpec) {
+	*out = *in
+	if in.Source != nil {
+		in, out := &in.Source, &out.Source
+		*out = new(ApplicationSource)
+		(*in).DeepCopyInto(*out)
+	}
+	out.Destination = in.Destination
+	if in.SyncPolicy != nil {
+		in, out := &in.SyncPolicy, &out.SyncPolicy
+		*out = new(SyncPolicy)
+		(*in).DeepCopyInto(*out)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSpec
+func (in *ApplicationSpec) DeepCopy() *ApplicationSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationStatus contains status information for the application
+type ApplicationStatus struct {
+	// Health contains information about the health status
+	Health HealthStatus `json:"health,omitempty"`
+	// Sync contains information about the sync status
+	Sync SyncStatus `json:"sync,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationStatus) DeepCopyInto(out *ApplicationStatus) {
+	*out = *in
+	out.Health = in.Health
+	out.Sync = in.Sync
+}
+
+// DeepCopy returns a deep copy of the ApplicationStatus
+func (in *ApplicationStatus) DeepCopy() *ApplicationStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// HealthStatus contains information about the health state
+type HealthStatus struct {
+	// Status holds the status code
+	Status string `json:"status,omitempty"`
+	// Message is a human-readable informational message
+	Message string `json:"message,omitempty"`
+}
+
+// SyncStatus contains information about the sync state
+type SyncStatus struct {
+	// Status is the sync state
+	Status string `json:"status"`
+	// Revision contains the revision the sync was performed against
+	Revision string `json:"revision,omitempty"`
+}
+
+// ApplicationSource contains information about the source of the application manifests
+type ApplicationSource struct {
+	// RepoURL is the URL to the repository
+	RepoURL string `json:"repoURL"`
+	// Path is the directory path within the repository
+	Path string `json:"path,omitempty"`
+	// TargetRevision is the revision to sync to
+	TargetRevision string `json:"targetRevision,omitempty"`
+	// Kustomize holds kustomize specific options
+	Kustomize *ApplicationSourceKustomize `json:"kustomize,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSource) DeepCopyInto(out *ApplicationSource) {
+	*out = *in
+	if in.Kustomize != nil {
+		in, out := &in.Kustomize, &out.Kustomize
+		*out = new(ApplicationSourceKustomize)
+		(*in).DeepCopyInto(*out)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSource
+func (in *ApplicationSource) DeepCopy() *ApplicationSource {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSource)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationSourceKustomize holds options specific to Kustomize
+type ApplicationSourceKustomize struct {
+	// NamePrefix is a prefix appended to resources
+	NamePrefix string `json:"namePrefix,omitempty"`
+	// NameSuffix is a suffix appended to resources
+	NameSuffix string `json:"nameSuffix,omitempty"`
+	// Namespace sets the namespace that Kustomize adds to all resources
+	Namespace string `json:"namespace,omitempty"`
+	// CommonLabels is a list of additional labels to add to rendered manifests
+	CommonLabels map[string]string `json:"commonLabels,omitempty"`
+	// CommonAnnotations is a list of additional annotations to add to rendered manifests
+	CommonAnnotations map[string]string `json:"commonAnnotations,omitempty"`
+	// Images is a list of Kustomize image overrides
+	Images []string `json:"images,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *ApplicationSourceKustomize) DeepCopyInto(out *ApplicationSourceKustomize) {
+	*out = *in
+	if in.CommonLabels != nil {
+		in, out := &in.CommonLabels, &out.CommonLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.CommonAnnotations != nil {
+		in, out := &in.CommonAnnotations, &out.CommonAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Images != nil {
+		in, out := &in.Images, &out.Images
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+}
+
+// DeepCopy returns a deep copy of the ApplicationSourceKustomize
+func (in *ApplicationSourceKustomize) DeepCopy() *ApplicationSourceKustomize {
+	if in == nil {
+		return nil
+	}
+	out := new(ApplicationSourceKustomize)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// ApplicationDestination contains information about the target cluster and namespace
+type ApplicationDestination struct {
+	// Server is the Kubernetes API server URL
+	Server string `json:"server,omitempty"`
+	// Namespace is the target namespace
+	Namespace string `json:"namespace,omitempty"`
+	// Name is the cluster name
+	Name string `json:"name,omitempty"`
+}
+
+// SyncPolicy controls when a sync will be performed
+type SyncPolicy struct {
+	// Automated will keep an application synced to the target revision
+	Automated *SyncPolicyAutomated `json:"automated,omitempty"`
+	// SyncOptions allow you to specify whole app sync-options
+	SyncOptions []string `json:"syncOptions,omitempty"`
+	// Retry controls failed sync retry behavior
+	Retry *RetryStrategy `json:"retry,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *SyncPolicy) DeepCopyInto(out *SyncPolicy) {
+	*out = *in
+	if in.Automated != nil {
+		in, out := &in.Automated, &out.Automated
+		*out = new(SyncPolicyAutomated)
+		**out = **in
+	}
+	if in.SyncOptions != nil {
+		in, out := &in.SyncOptions, &out.SyncOptions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Retry != nil {
+		in, out := &in.Retry, &out.Retry
+		*out = new(RetryStrategy)
+		(*in).DeepCopyInto(*out)
+	}
+}
+
+// DeepCopy returns a deep copy of the SyncPolicy
+func (in *SyncPolicy) DeepCopy() *SyncPolicy {
+	if in == nil {
+		return nil
+	}
+	out := new(SyncPolicy)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// SyncPolicyAutomated controls the behavior of an automated sync
+type SyncPolicyAutomated struct {
+	// Prune specifies whether to delete resources from the cluster that are not found in the sources anymore
+	Prune bool `json:"prune,omitempty"`
+	// SelfHeal specifies whether to revert resources back to their desired state upon modification
+	SelfHeal bool `json:"selfHeal,omitempty"`
+	// AllowEmpty allows apps have zero live resources
+	AllowEmpty bool `json:"allowEmpty,omitempty"`
+}
+
+// RetryStrategy controls the retry behavior
+type RetryStrategy struct {
+	// Limit is the maximum number of attempts for retrying a failed sync
+	Limit int64 `json:"limit,omitempty"`
+	// Backoff controls how to backoff on subsequent retries of failed syncs
+	Backoff *Backoff `json:"backoff,omitempty"`
+}
+
+// DeepCopyInto copies all properties of this object into another object of the same type
+func (in *RetryStrategy) DeepCopyInto(out *RetryStrategy) {
+	*out = *in
+	if in.Backoff != nil {
+		in, out := &in.Backoff, &out.Backoff
+		*out = new(Backoff)
+		**out = **in
+	}
+}
+
+// DeepCopy returns a deep copy of the RetryStrategy
+func (in *RetryStrategy) DeepCopy() *RetryStrategy {
+	if in == nil {
+		return nil
+	}
+	out := new(RetryStrategy)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// Backoff specifies backoff parameters
+type Backoff struct {
+	// Duration is the amount to back off
+	Duration string `json:"duration,omitempty"`
+	// Factor is the factor to back off by
+	Factor *int64 `json:"factor,omitempty"`
+	// MaxDuration is the maximum amount of time allowed for the backoff
+	MaxDuration string `json:"maxDuration,omitempty"`
+}

--- a/internal/argocd/types_test.go
+++ b/internal/argocd/types_test.go
@@ -1,0 +1,587 @@
+// Copyright 2025 The Previewd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TestApplicationSet_DeepCopy verifies DeepCopy returns a deep copy
+func TestApplicationSet_DeepCopy(t *testing.T) {
+	original := &ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-appset",
+			Namespace: "argocd",
+		},
+		Spec: ApplicationSetSpec{
+			GoTemplate: true,
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil for non-nil ApplicationSet")
+	}
+	if copied == original {
+		t.Error("DeepCopy() returned same pointer, expected deep copy")
+	}
+	if copied.Name != original.Name {
+		t.Errorf("DeepCopy() name = %v, want %v", copied.Name, original.Name)
+	}
+}
+
+// TestApplicationSet_DeepCopy_NilReceiver verifies DeepCopy handles nil receiver
+func TestApplicationSet_DeepCopy_NilReceiver(t *testing.T) {
+	var appSet *ApplicationSet
+	copied := appSet.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSet_DeepCopyObject verifies DeepCopyObject returns non-nil
+func TestApplicationSet_DeepCopyObject(t *testing.T) {
+	original := &ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+
+	copied := original.DeepCopyObject()
+
+	if copied == nil {
+		t.Fatal("DeepCopyObject() returned nil")
+	}
+}
+
+// TestApplicationSet_DeepCopyObject_NilReceiver verifies nil handling
+func TestApplicationSet_DeepCopyObject_NilReceiver(t *testing.T) {
+	var appSet *ApplicationSet
+	copied := appSet.DeepCopyObject()
+	if copied != nil {
+		t.Error("DeepCopyObject() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetList_DeepCopy verifies DeepCopy for list types
+func TestApplicationSetList_DeepCopy(t *testing.T) {
+	original := &ApplicationSetList{
+		Items: []ApplicationSet{
+			{ObjectMeta: metav1.ObjectMeta{Name: "item1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "item2"}},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if len(copied.Items) != len(original.Items) {
+		t.Errorf("DeepCopy() items length = %v, want %v", len(copied.Items), len(original.Items))
+	}
+}
+
+// TestApplicationSetList_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetList_DeepCopy_NilReceiver(t *testing.T) {
+	var list *ApplicationSetList
+	copied := list.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetList_DeepCopyObject verifies DeepCopyObject
+func TestApplicationSetList_DeepCopyObject(t *testing.T) {
+	original := &ApplicationSetList{}
+	copied := original.DeepCopyObject()
+	if copied == nil {
+		t.Fatal("DeepCopyObject() returned nil")
+	}
+}
+
+// TestApplicationSetList_DeepCopyObject_NilReceiver verifies nil handling
+func TestApplicationSetList_DeepCopyObject_NilReceiver(t *testing.T) {
+	var list *ApplicationSetList
+	copied := list.DeepCopyObject()
+	if copied != nil {
+		t.Error("DeepCopyObject() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetSpec_DeepCopy verifies DeepCopy for spec
+func TestApplicationSetSpec_DeepCopy(t *testing.T) {
+	original := &ApplicationSetSpec{
+		GoTemplate:        true,
+		GoTemplateOptions: []string{"missingkey=error"},
+		Generators: []ApplicationSetGenerator{
+			{List: &ListGenerator{}},
+		},
+		SyncPolicy: &ApplicationSetSyncPolicy{PreserveResourcesOnDeletion: true},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.SyncPolicy == original.SyncPolicy {
+		t.Error("DeepCopy() SyncPolicy should be a new pointer")
+	}
+}
+
+// TestApplicationSetSpec_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetSpec_DeepCopy_NilReceiver(t *testing.T) {
+	var spec *ApplicationSetSpec
+	copied := spec.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetStatus_DeepCopy verifies DeepCopy for status
+func TestApplicationSetStatus_DeepCopy(t *testing.T) {
+	original := &ApplicationSetStatus{
+		Conditions: []ApplicationSetCondition{
+			{Type: "Ready", Status: "True"},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if len(copied.Conditions) != len(original.Conditions) {
+		t.Errorf("DeepCopy() conditions length = %v, want %v", len(copied.Conditions), len(original.Conditions))
+	}
+}
+
+// TestApplicationSetStatus_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetStatus_DeepCopy_NilReceiver(t *testing.T) {
+	var status *ApplicationSetStatus
+	copied := status.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetGenerator_DeepCopy verifies DeepCopy for generator
+func TestApplicationSetGenerator_DeepCopy(t *testing.T) {
+	original := &ApplicationSetGenerator{
+		List: &ListGenerator{
+			Elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"service":"api"}`)},
+			},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.List == original.List {
+		t.Error("DeepCopy() List should be a new pointer")
+	}
+}
+
+// TestApplicationSetGenerator_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetGenerator_DeepCopy_NilReceiver(t *testing.T) {
+	var gen *ApplicationSetGenerator
+	copied := gen.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestListGenerator_DeepCopy verifies DeepCopy for list generator
+func TestListGenerator_DeepCopy(t *testing.T) {
+	original := &ListGenerator{
+		Elements: []apiextensionsv1.JSON{
+			{Raw: []byte(`{"key":"value"}`)},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+}
+
+// TestListGenerator_DeepCopy_NilReceiver verifies nil handling
+func TestListGenerator_DeepCopy_NilReceiver(t *testing.T) {
+	var gen *ListGenerator
+	copied := gen.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetTemplate_DeepCopy verifies DeepCopy for template
+func TestApplicationSetTemplate_DeepCopy(t *testing.T) {
+	original := &ApplicationSetTemplate{
+		ApplicationSetTemplateMeta: ApplicationSetTemplateMeta{
+			Name: "test-{{service}}",
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+}
+
+// TestApplicationSetTemplate_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetTemplate_DeepCopy_NilReceiver(t *testing.T) {
+	var template *ApplicationSetTemplate
+	copied := template.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSetTemplateMeta_DeepCopy verifies DeepCopy for template meta
+func TestApplicationSetTemplateMeta_DeepCopy(t *testing.T) {
+	original := &ApplicationSetTemplateMeta{
+		Name:        "test",
+		Namespace:   "argocd",
+		Labels:      map[string]string{"app": "test"},
+		Annotations: map[string]string{"note": "value"},
+		Finalizers:  []string{"foregroundDeletion"},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.Labels == nil {
+		t.Error("DeepCopy() Labels should not be nil")
+	}
+	// Verify maps are deep copied
+	copied.Labels["new"] = "value"
+	if _, exists := original.Labels["new"]; exists {
+		t.Error("DeepCopy() Labels should be a new map")
+	}
+}
+
+// TestApplicationSetTemplateMeta_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSetTemplateMeta_DeepCopy_NilReceiver(t *testing.T) {
+	var meta *ApplicationSetTemplateMeta
+	copied := meta.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplication_DeepCopy verifies DeepCopy for Application
+func TestApplication_DeepCopy(t *testing.T) {
+	original := &Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "argocd",
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied == original {
+		t.Error("DeepCopy() should return new pointer")
+	}
+}
+
+// TestApplication_DeepCopy_NilReceiver verifies nil handling
+func TestApplication_DeepCopy_NilReceiver(t *testing.T) {
+	var app *Application
+	copied := app.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplication_DeepCopyObject verifies DeepCopyObject
+func TestApplication_DeepCopyObject(t *testing.T) {
+	original := &Application{}
+	copied := original.DeepCopyObject()
+	if copied == nil {
+		t.Fatal("DeepCopyObject() returned nil")
+	}
+}
+
+// TestApplication_DeepCopyObject_NilReceiver verifies nil handling
+func TestApplication_DeepCopyObject_NilReceiver(t *testing.T) {
+	var app *Application
+	copied := app.DeepCopyObject()
+	if copied != nil {
+		t.Error("DeepCopyObject() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationList_DeepCopy verifies DeepCopy for list
+func TestApplicationList_DeepCopy(t *testing.T) {
+	original := &ApplicationList{
+		Items: []Application{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app1"}},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+}
+
+// TestApplicationList_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationList_DeepCopy_NilReceiver(t *testing.T) {
+	var list *ApplicationList
+	copied := list.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationList_DeepCopyObject verifies DeepCopyObject
+func TestApplicationList_DeepCopyObject(t *testing.T) {
+	original := &ApplicationList{}
+	copied := original.DeepCopyObject()
+	if copied == nil {
+		t.Fatal("DeepCopyObject() returned nil")
+	}
+}
+
+// TestApplicationList_DeepCopyObject_NilReceiver verifies nil handling
+func TestApplicationList_DeepCopyObject_NilReceiver(t *testing.T) {
+	var list *ApplicationList
+	copied := list.DeepCopyObject()
+	if copied != nil {
+		t.Error("DeepCopyObject() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSpec_DeepCopy verifies DeepCopy for spec
+func TestApplicationSpec_DeepCopy(t *testing.T) {
+	original := &ApplicationSpec{
+		Project: "default",
+		Source: &ApplicationSource{
+			RepoURL: "https://github.com/example/app",
+		},
+		SyncPolicy: &SyncPolicy{
+			Automated: &SyncPolicyAutomated{Prune: true},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.Source == original.Source {
+		t.Error("DeepCopy() Source should be new pointer")
+	}
+}
+
+// TestApplicationSpec_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSpec_DeepCopy_NilReceiver(t *testing.T) {
+	var spec *ApplicationSpec
+	copied := spec.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationStatus_DeepCopy verifies DeepCopy for status
+func TestApplicationStatus_DeepCopy(t *testing.T) {
+	original := &ApplicationStatus{
+		Health: HealthStatus{Status: "Healthy"},
+		Sync:   SyncStatus{Status: "Synced"},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+}
+
+// TestApplicationStatus_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationStatus_DeepCopy_NilReceiver(t *testing.T) {
+	var status *ApplicationStatus
+	copied := status.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSource_DeepCopy verifies DeepCopy for source
+func TestApplicationSource_DeepCopy(t *testing.T) {
+	original := &ApplicationSource{
+		RepoURL: "https://github.com/example/app",
+		Kustomize: &ApplicationSourceKustomize{
+			NamePrefix: "pr-123-",
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.Kustomize == original.Kustomize {
+		t.Error("DeepCopy() Kustomize should be new pointer")
+	}
+}
+
+// TestApplicationSource_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSource_DeepCopy_NilReceiver(t *testing.T) {
+	var source *ApplicationSource
+	copied := source.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestApplicationSourceKustomize_DeepCopy verifies DeepCopy for Kustomize
+func TestApplicationSourceKustomize_DeepCopy(t *testing.T) {
+	original := &ApplicationSourceKustomize{
+		NamePrefix:        "pr-123-",
+		Namespace:         "preview",
+		CommonLabels:      map[string]string{"pr": "123"},
+		CommonAnnotations: map[string]string{"note": "value"},
+		Images:            []string{"nginx:1.19"},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	// Verify maps are deep copied
+	copied.CommonLabels["new"] = "value"
+	if _, exists := original.CommonLabels["new"]; exists {
+		t.Error("DeepCopy() CommonLabels should be a new map")
+	}
+}
+
+// TestApplicationSourceKustomize_DeepCopy_NilReceiver verifies nil handling
+func TestApplicationSourceKustomize_DeepCopy_NilReceiver(t *testing.T) {
+	var kustomize *ApplicationSourceKustomize
+	copied := kustomize.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestSyncPolicy_DeepCopy verifies DeepCopy for sync policy
+func TestSyncPolicy_DeepCopy(t *testing.T) {
+	factor := int64(2)
+	original := &SyncPolicy{
+		Automated:   &SyncPolicyAutomated{Prune: true, SelfHeal: true},
+		SyncOptions: []string{"CreateNamespace=true"},
+		Retry: &RetryStrategy{
+			Limit: 5,
+			Backoff: &Backoff{
+				Duration:    "5s",
+				Factor:      &factor,
+				MaxDuration: "3m",
+			},
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.Automated == original.Automated {
+		t.Error("DeepCopy() Automated should be new pointer")
+	}
+	if copied.Retry == original.Retry {
+		t.Error("DeepCopy() Retry should be new pointer")
+	}
+}
+
+// TestSyncPolicy_DeepCopy_NilReceiver verifies nil handling
+func TestSyncPolicy_DeepCopy_NilReceiver(t *testing.T) {
+	var policy *SyncPolicy
+	copied := policy.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestRetryStrategy_DeepCopy verifies DeepCopy for retry strategy
+func TestRetryStrategy_DeepCopy(t *testing.T) {
+	factor := int64(2)
+	original := &RetryStrategy{
+		Limit: 5,
+		Backoff: &Backoff{
+			Duration:    "5s",
+			Factor:      &factor,
+			MaxDuration: "3m",
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	if copied == nil {
+		t.Fatal("DeepCopy() returned nil")
+	}
+	if copied.Backoff == original.Backoff {
+		t.Error("DeepCopy() Backoff should be new pointer")
+	}
+}
+
+// TestRetryStrategy_DeepCopy_NilReceiver verifies nil handling
+func TestRetryStrategy_DeepCopy_NilReceiver(t *testing.T) {
+	var strategy *RetryStrategy
+	copied := strategy.DeepCopy()
+	if copied != nil {
+		t.Error("DeepCopy() on nil receiver should return nil")
+	}
+}
+
+// TestAddKnownTypes verifies schema registration
+func TestAddKnownTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	err := AddToScheme(scheme)
+
+	if err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	// Verify types are registered
+	gvk := GroupVersion.WithKind("ApplicationSet")
+	if !scheme.Recognizes(gvk) {
+		t.Error("Scheme should recognize ApplicationSet")
+	}
+
+	gvk = GroupVersion.WithKind("Application")
+	if !scheme.Recognizes(gvk) {
+		t.Error("Scheme should recognize Application")
+	}
+}


### PR DESCRIPTION
## Summary

Implement ArgoCD ApplicationSet Builder and Manager that generates GitOps deployments for preview environments. This is a key component enabling automated deployment of services via ArgoCD when a preview environment is created.

### Key Features

- **BuildApplicationSet**: Creates ApplicationSet CR with list generator (one Application per service)
- **EnsureApplicationSet**: Idempotent create/update operations using controller-runtime
- **DeleteApplicationSet**: Idempotent deletion (returns nil if not found)
- **GetApplicationStatus**: Query Application health and sync status
- **Owner tracking via annotations**: Cross-namespace owner references are not supported by K8s, so we track ownership via annotations

### Technical Decisions

- Go templating enabled with `missingkey=error` for safer template evaluation
- Kustomize integration for namespace isolation and labeling
- Automated sync with prune, self-heal, and retry backoff (5s to 3m, 5 retries)
- Minimal local ArgoCD types in `types.go` to avoid complex transitive dependencies from the full ArgoCD package
- 31 comprehensive tests with 95-100% coverage on manager functions

### ApplicationSet Structure

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: preview-{prNumber}
  namespace: argocd
  labels:
    preview.previewd.io/pr: "{prNumber}"
    preview.previewd.io/managed-by: previewd
  annotations:
    preview.previewd.io/owner-name: {PreviewEnvironment.Name}
    preview.previewd.io/owner-namespace: {PreviewEnvironment.Namespace}
spec:
  goTemplate: true
  generators:
    - list:
        elements:
          - service: auth
          - service: api
  template:
    metadata:
      name: preview-{prNumber}-{{service}}
    spec:
      source:
        path: services/{{service}}
        kustomize:
          namePrefix: pr-{prNumber}-
          namespace: {namespace}
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
```

## Test Plan

- [x] All 31 tests pass (`go test ./internal/argocd/... -v`)
- [x] Test coverage: 95-100% on manager.go functions
- [x] Linting passes (`make lint`)
- [x] Tests cover all acceptance criteria from issue #6

### Tests Verify

- Name pattern: `preview-{prNumber}`
- Namespace: configured argocd namespace
- List generator with service elements from PreviewEnvironment.Spec.Services
- Sync policy: automated with prune and self-heal
- Sync options: CreateNamespace=false, PruneLast=true
- Kustomize: namespace, namePrefix, commonLabels
- Go template options: missingkey=error
- Owner reference annotations for cross-namespace tracking
- CRUD operations (create, update, delete)
- Application status retrieval

Closes #6